### PR TITLE
added <stdexcept> to the header

### DIFF
--- a/r-package/grftsls/src/src/forest/ForestOptions.cpp
+++ b/r-package/grftsls/src/src/forest/ForestOptions.cpp
@@ -18,6 +18,7 @@
 #include <random>
 #include "forest/ForestOptions.h"
 #include "tree/TreeOptions.h"
+#include <stdexcept>
 
 ForestOptions::ForestOptions(uint num_trees,
                              size_t ci_group_size,


### PR DESCRIPTION
Compilation of the package on Windows 10 rose an error: 'runtime_error' is not a member of 'std'. The error was solved by adding  <stdexcept>  to the header of the ForestOptions.cpp 